### PR TITLE
Make not to throw exceptions even if GITHUB_TOKEN is not set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.wantedly"
-version = "0.2.0"
+version = "0.2.1"
 
 repositories {
     jcenter()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,14 @@ repositories {
 
 dependencies {
     compileOnly(gradleApi())
-    implementation(platform(kotlin("bom")))
-    implementation(kotlin("gradle-plugin"))
+    compileOnly(platform(kotlin("bom")))
+    compileOnly(kotlin("gradle-plugin"))
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit"))
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 val sourcesJar by tasks.registering(Jar::class) {

--- a/src/main/kotlin/com/wantedly/maven/repository/MavenRepositoryPlugin.kt
+++ b/src/main/kotlin/com/wantedly/maven/repository/MavenRepositoryPlugin.kt
@@ -4,9 +4,13 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.credentials.AwsCredentials
 import org.gradle.kotlin.dsl.credentials
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URI
 import java.util.Properties
+
+private val logger: Logger = LoggerFactory.getLogger("WantedlyMavenRepository")
 
 /**
  * Adds a GitHub Packages Maven repository of Wantedly organization.
@@ -20,8 +24,12 @@ fun RepositoryHandler.wantedly(repo: String, group: String? = null): MavenArtifa
         url = URI("https://maven.pkg.github.com/wantedly/$repo")
         credentials {
             username = "not used but required"
-            password = getProp("GITHUB_TOKEN")
-                ?: throw IllegalStateException("You must set `GITHUB_TOKEN` environment variable or property.")
+
+            val ghToken = getProp("GITHUB_TOKEN")
+            if (ghToken.isNullOrEmpty()) {
+                logger.warn("You will get an authorization error unless setting `GITHUB_TOKEN` environment variable or `GITHUB_TOKEN` property in `local.properties`.")
+            }
+            password = ghToken
         }
         content {
             if (group != null) {

--- a/src/main/kotlin/com/wantedly/maven/repository/MavenRepositoryPlugin.kt
+++ b/src/main/kotlin/com/wantedly/maven/repository/MavenRepositoryPlugin.kt
@@ -27,7 +27,7 @@ fun RepositoryHandler.wantedly(repo: String, group: String? = null): MavenArtifa
 
             val ghToken = getProp("GITHUB_TOKEN")
             if (ghToken.isNullOrEmpty()) {
-                logger.warn("You will get an authorization error unless setting `GITHUB_TOKEN` environment variable or `GITHUB_TOKEN` property in `local.properties`.")
+                logger.warn("You will get an authorization error if you don't set `GITHUB_TOKEN` as an environment variable or as a property in `local.properties`.")
             }
             password = ghToken
         }


### PR DESCRIPTION
## Why

Because the `check` task fails on CI in spite of the `wantedly()` repository is not used.

## What

- Warn if `GITHUB_TOKEN` is not set instead of throwing an exception.
- Set `java.targetCompatibility = 1.8`.
