### PR TITLE
Release to Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,5 +21,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Build with Gradle
         uses: eskatos/gradle-command-action@v1.3.3
         with:
-          arguments: publish
+          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.ORG_GRADLE_PROJECT_OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.ORG_GRADLE_PROJECT_OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_OSSRH_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repository is public, so we can't write about secrets values, but you can f
 $ export ORG_GRADLE_PROJECT_signingKeyId=XXXXXXXXXXXX
 $ export ORG_GRADLE_PROJECT_signingKey=XXXXXXXXXXXX
 $ export ORG_GRADLE_PROJECT_signingPassword=XXXXXXXXXXXX
-$ export ORG_GRADLE_PROJECT_ossrhUsername=XXXXXXXXXXXX
-$ export ORG_GRADLE_PROJECT_ossrhPassword=XXXXXXXXXXXX
-$ ./gradlew clean publish
+$ export ORG_GRADLE_PROJECT_sonatypeUsername=XXXXXXXXXXXX
+$ export ORG_GRADLE_PROJECT_sonatypePassword=XXXXXXXXXXXX
+$ ./gradlew clean publishToSonatype closeAndReleaseSonatypeStagingRepository
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,8 @@ publishing {
 }
 
 tasks.all {
-    // We need to disable `pluginMaven` publication tasks.
+    // The `kotlin-dsl` plugin automatically generates a `pluginMaven` publishing task to publish Gradle plugins,
+    // but since there are no Gradle plugins to publish in this project, the `pluginMaven` publishing task is disabled.
     // https://github.com/gradle/gradle/issues/14993#issuecomment-717883699
     if ("PluginMavenPublication" in name) {
         enabled = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,19 +44,6 @@ val sourcesJar by tasks.registering(Jar::class) {
 }
 
 publishing {
-//    repositories {
-//        maven {
-//            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-//            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-//            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-//            credentials {
-//                val sonatypeUsername: String? by project
-//                val sonatypePassword: String? by project
-//                username = sonatypeUsername
-//                password = sonatypePassword
-//            }
-//        }
-//    }
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.wantedly"
-version = "1.0.1-SNAPSHOT"
+version = "1.0.1"
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     // Gradle requires targeting 1.8 or higher.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.wantedly"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 
 repositories {
     mavenCentral()
@@ -40,8 +40,9 @@ val sourcesJar by tasks.registering(Jar::class) {
 publishing {
     repositories {
         maven {
-            val releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            val snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            // TODO: Needs migrate to s01.oss.sonatype.org
+            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
             url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
             credentials {
                 val ossrhUsername: String? by project
@@ -52,7 +53,7 @@ publishing {
         }
     }
     publications {
-        register<MavenPublication>("maven") {
+        create<MavenPublication>("maven") {
             from(components["java"])
             artifact(javadocJar.get())
             artifact(sourcesJar.get())
@@ -82,6 +83,14 @@ publishing {
                 }
             }
         }
+    }
+}
+
+tasks.all {
+    // We need to disable `pluginMaven` publication tasks.
+    // https://github.com/gradle/gradle/issues/14993#issuecomment-717883699
+    if ("PluginMavenPublication" in name) {
+        enabled = false
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,10 +45,6 @@ val sourcesJar by tasks.registering(Jar::class) {
 publishing {
     repositories {
         maven {
-            // TODO: Needs migrate to s01.oss.sonatype.org after release completed.
-            // > Note: As of February 2021, all new projects began being provisioned on https://s01.oss.sonatype.org/.
-            // > If your project is not provisioned on https://s01.oss.sonatype.org/,
-            // > please login to the legacy host https://oss.sonatype.org/.
             val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
             url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,11 @@ plugins {
     `maven-publish`
     signing
     id("org.jetbrains.dokka") version "1.4.20"
+    id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 }
 
 group = "com.wantedly"
-version = "1.0.0"
+version = "1.0.1-SNAPSHOT"
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     // Gradle requires targeting 1.8 or higher.
@@ -43,19 +44,19 @@ val sourcesJar by tasks.registering(Jar::class) {
 }
 
 publishing {
-    repositories {
-        maven {
-            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-            credentials {
-                val ossrhUsername: String? by project
-                val ossrhPassword: String? by project
-                username = ossrhUsername
-                password = ossrhPassword
-            }
-        }
-    }
+//    repositories {
+//        maven {
+//            val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+//            val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+//            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+//            credentials {
+//                val sonatypeUsername: String? by project
+//                val sonatypePassword: String? by project
+//                username = sonatypeUsername
+//                password = sonatypePassword
+//            }
+//        }
+//    }
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
@@ -107,4 +108,10 @@ signing {
     @Suppress("UnstableApiUsage")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications["maven"])
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,10 @@ val sourcesJar by tasks.registering(Jar::class) {
 publishing {
     repositories {
         maven {
-            // TODO: Needs migrate to s01.oss.sonatype.org
+            // TODO: Needs migrate to s01.oss.sonatype.org after release completed.
+            // > Note: As of February 2021, all new projects began being provisioned on https://s01.oss.sonatype.org/.
+            // > If your project is not provisioned on https://s01.oss.sonatype.org/,
+            // > please login to the legacy host https://oss.sonatype.org/.
             val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
             url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,11 @@ plugins {
 group = "com.wantedly"
 version = "1.0.0"
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
+    // Gradle requires targeting 1.8 or higher.
+    kotlinOptions.jvmTarget = "1.8"
+}
+
 repositories {
     mavenCentral()
     // Workaround: https://github.com/Kotlin/dokka/issues/41


### PR DESCRIPTION
## Why

Part of #6
To release artifacts to Maven Central.

## What

- Fixes publish configurations.
- Introduce [`nexus-publish`](https://github.com/gradle-nexus/publish-plugin/) plugin to reduce the manual operations.