### PR TITLE
File取り込みをkonanを使用しない形に変更

### DIFF
--- a/src/main/kotlin/com/wantedly/maven/repository/RepositoryHandler.wantedly.kt
+++ b/src/main/kotlin/com/wantedly/maven/repository/RepositoryHandler.wantedly.kt
@@ -2,11 +2,11 @@ package com.wantedly.maven.repository
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
-import org.jetbrains.kotlin.konan.properties.loadProperties
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.URI
+import java.util.Properties
 
 private val logger: Logger = LoggerFactory.getLogger("WantedlyMavenRepository")
 
@@ -41,5 +41,8 @@ fun RepositoryHandler.wantedly(repo: String, group: String? = null): MavenArtifa
 
 private fun getProp(name: String): String? {
     return System.getenv(name)
-        ?: File("local.properties").takeIf { it.exists() }?.let { loadProperties(it.path).getProperty(name) }
+        ?: File("local.properties").takeIf { it.exists() }?.let { file ->
+            file.inputStream()
+                .use { stream -> Properties().apply { load(stream) }.getProperty(name) }
+        }
 }


### PR DESCRIPTION
## Why

三好win環境で動作しないため

## What

kotlinのクラスを使用しないクラシカルな実装に変更しました(こちらでは自分の手元(win, mac共に)動きます)