### PR TITLE
Upgrade Java version from 1.8 to 17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build with Gradle
-      uses: eskatos/gradle-command-action@v1.3.3
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '17'
+          distribution: 'temurin'
       - name: Build with Gradle
-        uses: eskatos/gradle-command-action@v1.3.3
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,22 +3,27 @@ plugins {
     kotlin("jvm") version embeddedKotlinVersion
     `maven-publish`
     signing
-    id("org.jetbrains.dokka") version "1.4.20"
+    id("org.jetbrains.dokka") version "1.9.10"
     id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
 }
 
 group = "com.wantedly"
 version = "1.1.0"
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-    // Gradle requires targeting 1.8 or higher.
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
 }
 
 repositories {
     mavenCentral()
-    // Workaround: https://github.com/Kotlin/dokka/issues/41
-    jcenter()
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 概要
OSSRH終了に伴うCentral Portal移行の準備として、Java環境を現代的なバージョンにアップグレードしました。

## 変更内容
### Java環境のアップグレード
- Java 1.8 → Java 17 (LTS版)
- JVM Toolchain を使用して統一した設定

### ビルド環境の改善
- **Gradle**: 6.6.1 → 8.5
- **Dokka**: 1.4.20 → 1.9.10  
- **廃止されたjcenterリポジトリを削除**

### GitHub Actions の更新
- **Java**: 1.8 → 17
- **actions/checkout**: v2 → v4
- **actions/setup-java**: v1 → v4  
- **gradle-command-action** → **gradle/gradle-build-action@v2**

## 検証済み
- ✅ ローカルビルドが正常に成功
- ✅ すべての依存関係が正しく解決

## 次のステップ
この変更後、Central Portal への移行設定を進める予定です。

## 関連
- OSSRH終了: 2025年6月30日
- Central Portal移行が必要 