### PR TITLE
Migrate from OSSRH to Central Portal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,5 +22,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_CENTRAL_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,5 +22,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_CENTRAL_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,5 +22,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     `maven-publish`
     signing
     id("org.jetbrains.dokka") version "1.9.10"
-    id("io.github.gradle-nexus.publish-plugin") version "1.0.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 group = "com.wantedly"
@@ -104,6 +104,10 @@ signing {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype {
+            // Central Portal用の新しいURL
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,6 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            // Central Portal用の新しいURL
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }


### PR DESCRIPTION
## 概要
OSSRH終了（2025年6月30日）に伴い、Maven Central への公開を Legacy OSSRH から Central Portal に移行します。

## 変更内容

### 🔧 ビルド設定の更新
- **nexus-publish-plugin**: `1.0.0` → `2.0.0` (Central Portal対応版)
- **nexusPublishing設定**: Central Portal用URLに変更
  - Staging URL: `https://ossrh-staging-api.central.sonatype.com/service/local/`
  - Snapshot URL: `https://central.sonatype.com/repository/maven-snapshots/`

### 🔐 認証設定の更新
- **GitHub Actions**: Central Portal用認証シークレットを使用
  - `CENTRAL_TOKEN_USERNAME` (Central Portal ユーザートークンのユーザー名)
  - `CENTRAL_TOKEN_PASSWORD` (Central Portal ユーザートークンのパスワード)

## ⚠️ 注意事項

### マージ前に必要な作業
1. **Central Portal でのセットアップ**
   - https://central.sonatype.com/ でアカウント作成
   - `com.wantedly` ネームスペースの検証
   - ユーザートークンの生成

2. **GitHub Secrets の追加**
   - `CENTRAL_TOKEN_USERNAME`: Central Portal ユーザートークンのユーザー名
   - `CENTRAL_TOKEN_PASSWORD`: Central Portal ユーザートークンのパスワード

### 既存のシークレット
以下は引き続き使用されます：
- `ORG_GRADLE_PROJECT_SIGNING_KEY_ID`
- `ORG_GRADLE_PROJECT_SIGNING_KEY`  
- `ORG_GRADLE_PROJECT_SIGNING_PASSWORD`

## 🧪 検証済み
- ✅ ローカルビルドが正常に成功
- ✅ 新しいプラグインバージョンとの互換性確認

## 📚 参考資料
- [OSSRH終了アナウンス](https://central.sonatype.org/news/20250326_ossrh_sunset/)
- [Central Portal移行ガイド](https://central.sonatype.org/publish/publish-portal-gradle/)

## 🔄 移行スケジュール
- **OSSRH終了日**: 2025年6月30日
- **移行期限**: 2025年6月30日まで 